### PR TITLE
Make sure webserver executable builds before doing integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: cpp
+
+dist: trusty
+sudo: required
 script:
 - make
-- make check && ./server_integration_test.sh
+- make check
 addons:
  apt:
    packages:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SERVER = server
 SERVER_TEST = server_test
 CONNECTION = connection
 CONNECTION_TEST = connection_test
+INTEGRATION_TEST = server_integration_test.sh
 
 PARSER_SOURCE = config_parser.cc config_parser_main.cc
 SERVER_SOURCE = connection.cc server.cc main.cc config_parser.cc
@@ -27,13 +28,16 @@ parser:	$(PARSER_SOURCE)
 webserver: $(SERVER_SOURCE)
 	$(CC) $(CFLAGS) $^ -o $@ -lboost_system
 
-check: check_config check_server check_connection
+check: webserver check_config check_server check_connection integ_test
 
 check_config: config_test
 	./$(CONFIG_TEST)
 
 check_server: server_test
 	./$(SERVER_TEST)
+
+integ_test:
+	./$(INTEGRATION_TEST)
 
 check_connection: connection_test
 	./$(CONNECTION_TEST)

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -156,7 +156,7 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
   while (true) {
     std::string token;
     token_type = ParseToken(config_file, &token);
-    printf ("%s: %s\n", TokenTypeAsString(token_type), token.c_str());
+    // printf ("%s: %s\n", TokenTypeAsString(token_type), token.c_str());
     if (token_type == TOKEN_TYPE_ERROR) {
       break;
     }
@@ -225,9 +225,9 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
     last_token_type = token_type;
   }
 
-  printf ("Bad transition from %s to %s\n",
-          TokenTypeAsString(last_token_type),
-          TokenTypeAsString(token_type));
+  // printf ("Bad transition from %s to %s\n",
+  //         TokenTypeAsString(last_token_type),
+  //         TokenTypeAsString(token_type));
   return false;
 }
 


### PR DESCRIPTION
This fixed the build.
Also removed some lines from config_parser.cc to make tests look cleaner.