### PR TITLE
Adding unit tests for handlers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOURCES = $(CLASSES:=.cc)
 OBJECTS = $(CLASSES:=.o)
 # TODO: make tests of the rest of the .cc files. For now, using ACTUAL_TESTS instead of TESTS
 TESTS = $(CLASSES:=_test.cc)
-ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test
+ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test
 ACTUAL_TESTS_SOURCE = $(ACTUAL_TESTS:=.cc)
 GCOV = config_parser/config_parser.cc src/connection.cc src/request.cc src/server.cc
 
@@ -53,7 +53,7 @@ libgmock.a:
 
 clean:
 	$(RM) *.o *~ *.a *.gcov *.gcda *.gcno webserver
-	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test
+	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test
 	$(RM) config_parser/*.o config_parser/*~ config_parser/*.gcda config_parser/*.gcno config_parser/config_parser_test
 
 .PHONY: all gcov check clean

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOURCES = $(CLASSES:=.cc)
 OBJECTS = $(CLASSES:=.o)
 # TODO: make tests of the rest of the .cc files. For now, using ACTUAL_TESTS instead of TESTS
 TESTS = $(CLASSES:=_test.cc)
-ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test src/echo_handler_test
+ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test src/echo_handler_test src/static_handler_test
 ACTUAL_TESTS_SOURCE = $(ACTUAL_TESTS:=.cc)
 GCOV = config_parser/config_parser.cc src/connection.cc src/request.cc src/server.cc
 
@@ -53,7 +53,7 @@ libgmock.a:
 
 clean:
 	$(RM) *.o *~ *.a *.gcov *.gcda *.gcno webserver
-	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test src/echo_handler_test
+	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test src/echo_handler_test src/static_handler_test
 	$(RM) config_parser/*.o config_parser/*~ config_parser/*.gcda config_parser/*.gcno config_parser/config_parser_test
 
 .PHONY: all gcov check clean

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOURCES = $(CLASSES:=.cc)
 OBJECTS = $(CLASSES:=.o)
 # TODO: make tests of the rest of the .cc files. For now, using ACTUAL_TESTS instead of TESTS
 TESTS = $(CLASSES:=_test.cc)
-ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test
+ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test src/echo_handler_test
 ACTUAL_TESTS_SOURCE = $(ACTUAL_TESTS:=.cc)
 GCOV = config_parser/config_parser.cc src/connection.cc src/request.cc src/server.cc
 
@@ -53,7 +53,7 @@ libgmock.a:
 
 clean:
 	$(RM) *.o *~ *.a *.gcov *.gcda *.gcno webserver
-	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test
+	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test src/echo_handler_test
 	$(RM) config_parser/*.o config_parser/*~ config_parser/*.gcda config_parser/*.gcno config_parser/config_parser_test
 
 .PHONY: all gcov check clean

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOURCES = $(CLASSES:=.cc)
 OBJECTS = $(CLASSES:=.o)
 # TODO: make tests of the rest of the .cc files. For now, using ACTUAL_TESTS instead of TESTS
 TESTS = $(CLASSES:=_test.cc)
-ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test src/echo_handler_test src/static_handler_test
+ACTUAL_TESTS = config_parser/config_parser_test src/connection_test src/request_test src/server_test src/not_found_handler_test src/echo_handler_test src/static_handler_test src/status_handler_test
 ACTUAL_TESTS_SOURCE = $(ACTUAL_TESTS:=.cc)
 GCOV = config_parser/config_parser.cc src/connection.cc src/request.cc src/server.cc
 
@@ -53,7 +53,7 @@ libgmock.a:
 
 clean:
 	$(RM) *.o *~ *.a *.gcov *.gcda *.gcno webserver
-	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test src/echo_handler_test src/static_handler_test
+	$(RM) src/*.o src/*~ src/*.gcda src/*.gcno src/server_test src/request_test src/connection_test src/not_found_handler_test src/echo_handler_test src/static_handler_test src/status_handler_test
 	$(RM) config_parser/*.o config_parser/*~ config_parser/*.gcda config_parser/*.gcno config_parser/config_parser_test
 
 .PHONY: all gcov check clean

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -1,0 +1,35 @@
+#define TEST_ECHO_HANDLER
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "request.h"
+#include "response.h"
+#include "config_parser.h"
+#include "echo_handler.h"
+
+class EchoHandlerTest : public ::testing::Test {
+ protected:
+  EchoHandlerTest() {
+    status = echo_handler.Init(uri_prefix, config);
+    request = Request::Parse(TEST_BUFFER);
+  }
+
+  EchoHandler echo_handler;
+  const std::string uri_prefix;
+  const NginxConfig config;
+  const std::string TEST_BUFFER = "GET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
+  const std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nGET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
+  RequestHandler::Status status;
+  std::unique_ptr<Request> request;
+};
+
+TEST_F(EchoHandlerTest, InitTest) {
+  EXPECT_EQ(status, RequestHandler::Status::OK);
+}
+
+TEST_F(EchoHandlerTest, HandleProperRequestTest) {
+  Response response;
+  EXPECT_EQ(echo_handler.HandleRequest(*request, &response), RequestHandler::Status::OK);
+  EXPECT_EQ(response.GetResponseCode(), Response::OK);
+  EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
+}

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -10,26 +10,26 @@
 class EchoHandlerTest : public ::testing::Test {
  protected:
   EchoHandlerTest() {
-    status = echo_handler.Init(uri_prefix, config);
+    status = echo_handler.Init(uri_prefix_, config_);
     request = Request::Parse(TEST_BUFFER);
   }
 
-  EchoHandler echo_handler;
-  const std::string uri_prefix;
-  const NginxConfig config;
+  EchoHandler echo_handler_;
+  const std::string uri_prefix_;
+  const NginxConfig config_;
   const std::string TEST_BUFFER = "GET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
   const std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nGET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
-  RequestHandler::Status status;
-  std::unique_ptr<Request> request;
+  RequestHandler::Status status_;
+  std::unique_ptr<Request> request_;
 };
 
 TEST_F(EchoHandlerTest, InitTest) {
-  EXPECT_EQ(status, RequestHandler::Status::OK);
+  EXPECT_EQ(status_, RequestHandler::Status::OK);
 }
 
 TEST_F(EchoHandlerTest, HandleProperRequestTest) {
   Response response;
-  EXPECT_EQ(echo_handler.HandleRequest(*request, &response), RequestHandler::Status::OK);
+  EXPECT_EQ(echo_handler_.HandleRequest(*request_, &response), RequestHandler::Status::OK);
   EXPECT_EQ(response.GetResponseCode(), Response::OK);
   EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
 }

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -10,8 +10,8 @@
 class EchoHandlerTest : public ::testing::Test {
  protected:
   EchoHandlerTest() {
-    status = echo_handler.Init(uri_prefix_, config_);
-    request = Request::Parse(TEST_BUFFER);
+    status_ = echo_handler.Init(uri_prefix_, config_);
+    request_ = Request::Parse(TEST_BUFFER);
   }
 
   EchoHandler echo_handler_;

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -10,13 +10,13 @@
 class EchoHandlerTest : public ::testing::Test {
  protected:
   EchoHandlerTest() {
-    status_ = echo_handler_.Init(uri_prefix_, config_);
+    std::string uri_prefix;  
+    NginxConfig config; 
+    status_ = echo_handler_.Init(uri_prefix, config);    
     request_ = Request::Parse(TEST_BUFFER);
   }
 
   EchoHandler echo_handler_;
-  const std::string uri_prefix_;
-  const NginxConfig config_;
   const std::string TEST_BUFFER = "GET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
   const std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nGET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
   RequestHandler::Status status_;

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -1,5 +1,3 @@
-#define TEST_ECHO_HANDLER
-
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "request.h"

--- a/src/echo_handler_test.cc
+++ b/src/echo_handler_test.cc
@@ -10,7 +10,7 @@
 class EchoHandlerTest : public ::testing::Test {
  protected:
   EchoHandlerTest() {
-    status_ = echo_handler.Init(uri_prefix_, config_);
+    status_ = echo_handler_.Init(uri_prefix_, config_);
     request_ = Request::Parse(TEST_BUFFER);
   }
 

--- a/src/not_found_handler_test.cc
+++ b/src/not_found_handler_test.cc
@@ -1,0 +1,33 @@
+#define TEST_NOT_FOUND_HANDLER
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "request.h"
+#include "response.h"
+#include "config_parser.h"
+#include "not_found_handler.h"
+
+class NotFoundHandlerTest : public ::testing::Test {
+ protected:
+  NotFoundHandlerTest() {
+    status = not_found_handler.Init(uri_prefix, config);
+  }
+
+  NotFoundHandler not_found_handler;
+  const std::string uri_prefix;
+  const NginxConfig config;
+  const std::string EXPECTED_RESPONSE = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>404 Not Found</h1></body></html>";
+  RequestHandler::Status status;
+};
+
+TEST_F(NotFoundHandlerTest, InitTest) {
+  EXPECT_EQ(status, RequestHandler::Status::OK);
+}
+
+TEST_F(NotFoundHandlerTest, HandleProperRequestTest) {
+  Request request;
+  Response response;
+  EXPECT_EQ(not_found_handler.HandleRequest(request, &response), RequestHandler::Status::OK);
+  EXPECT_EQ(response.GetResponseCode(), Response::NOT_FOUND);
+  EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
+}

--- a/src/not_found_handler_test.cc
+++ b/src/not_found_handler_test.cc
@@ -1,5 +1,3 @@
-#define TEST_NOT_FOUND_HANDLER
-
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "request.h"

--- a/src/not_found_handler_test.cc
+++ b/src/not_found_handler_test.cc
@@ -10,12 +10,12 @@
 class NotFoundHandlerTest : public ::testing::Test {
  protected:
   NotFoundHandlerTest() {
-    status = not_found_handler_.Init(uri_prefix_, config_);
+    const std::string uri_prefix;
+    const NginxConfig config;
+    status_ = not_found_handler_.Init(uri_prefix, config);
   }
 
   NotFoundHandler not_found_handler_;
-  const std::string uri_prefix_;
-  const NginxConfig config_;
   const std::string EXPECTED_RESPONSE = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>404 Not Found</h1></body></html>";
   RequestHandler::Status status_;
 };
@@ -27,7 +27,7 @@ TEST_F(NotFoundHandlerTest, InitTest) {
 TEST_F(NotFoundHandlerTest, HandleProperRequestTest) {
   Request request;
   Response response;
-  EXPECT_EQ(not_found_handler.HandleRequest(request, &response), RequestHandler::Status::OK);
+  EXPECT_EQ(not_found_handler_.HandleRequest(request, &response), RequestHandler::Status::OK);
   EXPECT_EQ(response.GetResponseCode(), Response::NOT_FOUND);
   EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
 }

--- a/src/not_found_handler_test.cc
+++ b/src/not_found_handler_test.cc
@@ -10,18 +10,18 @@
 class NotFoundHandlerTest : public ::testing::Test {
  protected:
   NotFoundHandlerTest() {
-    status = not_found_handler.Init(uri_prefix, config);
+    status = not_found_handler_.Init(uri_prefix_, config_);
   }
 
-  NotFoundHandler not_found_handler;
-  const std::string uri_prefix;
-  const NginxConfig config;
+  NotFoundHandler not_found_handler_;
+  const std::string uri_prefix_;
+  const NginxConfig config_;
   const std::string EXPECTED_RESPONSE = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>404 Not Found</h1></body></html>";
-  RequestHandler::Status status;
+  RequestHandler::Status status_;
 };
 
 TEST_F(NotFoundHandlerTest, InitTest) {
-  EXPECT_EQ(status, RequestHandler::Status::OK);
+  EXPECT_EQ(status_, RequestHandler::Status::OK);
 }
 
 TEST_F(NotFoundHandlerTest, HandleProperRequestTest) {

--- a/src/static_handler.cc
+++ b/src/static_handler.cc
@@ -21,6 +21,7 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
 
   // get relative path by taking the request URI, removing the StaticHandler's
   // URI prefix, and prepending the root path
+  std::cout << "GOT URI:" + request.uri() << std::endl;
   std::string uri = request.uri();
   std::string relative_path_string;
   if (uri != uri_prefix_ 
@@ -38,6 +39,8 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
     boost::filesystem::path absolute_path = boost::filesystem::canonical(
         relative_path);
 
+    std::cout << "RELATIVE PATH" << std::endl;
+
     // get name of base directory
     std::string dir = boost::filesystem::canonical(
         boost::filesystem::path(root_)).filename().string();
@@ -46,6 +49,9 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
     if (absolute_path.string().find(dir) != std::string::npos) {
       boost::filesystem::ifstream ifs(absolute_path, 
                                       std::ios::in | std::ios::binary);
+
+      std::cout << "ABSOLUTE PATH" << std::endl;
+
       if (ifs) {
         // read file into response body
         std::ostringstream oss;
@@ -56,6 +62,8 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
         // set mime type
         std::string extension = absolute_path.extension().string();
         response->AddHeader(CONTENT_TYPE_, GetMimeType(extension));
+
+        std::cout << "GOT IT" << std::endl;
 
         response->SetStatus(Response::OK);
         return OK;

--- a/src/static_handler.cc
+++ b/src/static_handler.cc
@@ -21,7 +21,6 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
 
   // get relative path by taking the request URI, removing the StaticHandler's
   // URI prefix, and prepending the root path
-  std::cout << "GOT URI:" + request.uri() << std::endl;
   std::string uri = request.uri();
   std::string relative_path_string;
   if (uri != uri_prefix_ 
@@ -39,8 +38,6 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
     boost::filesystem::path absolute_path = boost::filesystem::canonical(
         relative_path);
 
-    std::cout << "RELATIVE PATH" << std::endl;
-
     // get name of base directory
     std::string dir = boost::filesystem::canonical(
         boost::filesystem::path(root_)).filename().string();
@@ -49,8 +46,6 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
     if (absolute_path.string().find(dir) != std::string::npos) {
       boost::filesystem::ifstream ifs(absolute_path, 
                                       std::ios::in | std::ios::binary);
-
-      std::cout << "ABSOLUTE PATH" << std::endl;
 
       if (ifs) {
         // read file into response body
@@ -62,8 +57,6 @@ RequestHandler::Status StaticHandler::HandleRequest(const Request& request,
         // set mime type
         std::string extension = absolute_path.extension().string();
         response->AddHeader(CONTENT_TYPE_, GetMimeType(extension));
-
-        std::cout << "GOT IT" << std::endl;
 
         response->SetStatus(Response::OK);
         return OK;

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -5,7 +5,6 @@
 #include "config_parser.h"
 #include "static_handler.h"
 
-class MockRequest : public Request {};
 class MockResponse : public Response {};
 class MockNginxConfigParser : public NginxConfigParser {};
 class MockNginxConfig : public NginxConfig {};
@@ -16,7 +15,7 @@ class StaticHandlerTest : public ::testing::Test {
     const std::string uri_prefix = "/static";
     ParseString("root ./example_files;");
     status_ = static_handler_.Init(uri_prefix, config_);
-    request_ = MockRequest::Parse(TEST_BUFFER);
+    request_ = Request::Parse(TEST_BUFFER);
   }
 
   bool ParseString(const std::string config_string) {
@@ -31,7 +30,7 @@ class StaticHandlerTest : public ::testing::Test {
   const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
   std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Server Test</title>\r\n</head>\r\n<body>\r\n<h1>Testing testing 1 2 3...</h1>\r\n<p>Looks like the server is working!</p>\r\n</body>\r\n</html>";
   RequestHandler::Status status_;
-  std::unique_ptr<MockRequest> request_;
+  std::unique_ptr<Request> request_;
   MockResponse response_;
 };
 

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -10,7 +10,7 @@
 class StaticHandlerTest : public ::testing::Test {
  protected:
   StaticHandlerTest() {
-    ParseString("test_config");
+    ParseString("root ./example_files;");
     status = static_handler.Init(uri_prefix, config);
     request = Request::Parse(TEST_BUFFER);
   }
@@ -25,7 +25,7 @@ class StaticHandlerTest : public ::testing::Test {
   StaticHandler static_handler;
   const std::string uri_prefix = "/static";
   const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
-  const std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nGET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
+  std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Server Test</title>\r\n</head>\r\n<body>\r\n<h1>Testing testing 1 2 3...</h1>\r\n<p>Looks like the server is working!</p>\r\n</body>\r\n</html>";
   RequestHandler::Status status;
   std::unique_ptr<Request> request;
   Response response;
@@ -41,9 +41,6 @@ TEST_F(StaticHandlerTest, NullResponse) {
 
 TEST_F(StaticHandlerTest, HandleProperRequestTest) {
   EXPECT_EQ(static_handler.HandleRequest(*request, &response), RequestHandler::Status::OK);
-  // EXPECT_EQ(response.GetResponseCode(), Response::OK);
-  std::cout << "URI IS: " + request->uri() << std::endl;
-  std::cout << request->raw_request() << std::endl;
-  std::cout << response.ToString();
-  // EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
+  EXPECT_EQ(response.GetResponseCode(), Response::OK);
+  EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
 }

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -1,0 +1,49 @@
+#define TEST_STATIC_HANDLER
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "request.h"
+#include "response.h"
+#include "config_parser.h"
+#include "static_handler.h"
+
+class StaticHandlerTest : public ::testing::Test {
+ protected:
+  StaticHandlerTest() {
+    ParseString("test_config");
+    status = static_handler.Init(uri_prefix, config);
+    request = Request::Parse(TEST_BUFFER);
+  }
+
+  bool ParseString(const std::string config_string) {
+    std::stringstream config_stream(config_string);
+    return parser.Parse(&config_stream, &config);
+  }
+  NginxConfigParser parser;
+  NginxConfig config;
+
+  StaticHandler static_handler;
+  const std::string uri_prefix = "/static";
+  const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
+  const std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nGET /echo HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
+  RequestHandler::Status status;
+  std::unique_ptr<Request> request;
+  Response response;
+};
+
+TEST_F(StaticHandlerTest, InitTest) {
+  EXPECT_EQ(status, RequestHandler::Status::OK);
+}
+
+TEST_F(StaticHandlerTest, NullResponse) {
+  EXPECT_EQ(static_handler.HandleRequest(*request, nullptr), RequestHandler::Status::ERROR);
+}
+
+TEST_F(StaticHandlerTest, HandleProperRequestTest) {
+  EXPECT_EQ(static_handler.HandleRequest(*request, &response), RequestHandler::Status::OK);
+  // EXPECT_EQ(response.GetResponseCode(), Response::OK);
+  std::cout << "URI IS: " + request->uri() << std::endl;
+  std::cout << request->raw_request() << std::endl;
+  std::cout << response.ToString();
+  // EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
+}

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -5,28 +5,33 @@
 #include "config_parser.h"
 #include "static_handler.h"
 
+class MockRequest : public Request {};
+class MockResponse : public Response {};
+class MockNginxConfigParser : public NginxConfigParser {};
+class MockNginxConfig : public NginxConfig {};
+
 class StaticHandlerTest : public ::testing::Test {
  protected:
   StaticHandlerTest() {
     ParseString("root ./example_files;");
     status_ = static_handler.Init(uri_prefix_, config_);
-    request_ = Request::Parse(TEST_BUFFER);
+    request_ = MockRequest::Parse(TEST_BUFFER);
   }
 
   bool ParseString(const std::string config_string) {
     std::stringstream config_stream(config_string);
     return parser_.Parse(&config_stream, &config_);
   }
-  NginxConfigParser parser_;
-  NginxConfig config_;
+  MockNginxConfigParser parser_;
+  MockNginxConfig config_;
 
   StaticHandler static_handler_;
   const std::string uri_prefix_ = "/static";
   const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
   std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Server Test</title>\r\n</head>\r\n<body>\r\n<h1>Testing testing 1 2 3...</h1>\r\n<p>Looks like the server is working!</p>\r\n</body>\r\n</html>";
   RequestHandler::Status status_;
-  std::unique_ptr<Request> request_;
-  Response response_;
+  std::unique_ptr<MockRequest> request_;
+  MockResponse response_;
 };
 
 TEST_F(StaticHandlerTest, InitTest) {
@@ -39,6 +44,6 @@ TEST_F(StaticHandlerTest, NullResponse) {
 
 TEST_F(StaticHandlerTest, HandleProperRequestTest) {
   EXPECT_EQ(static_handler_.HandleRequest(*request_, &response_), RequestHandler::Status::OK);
-  EXPECT_EQ(response_.GetResponseCode(), Response::OK);
+  EXPECT_EQ(response_.GetResponseCode(), MockResponse::OK);
   EXPECT_EQ(response_.ToString(), EXPECTED_RESPONSE);
 }

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -1,5 +1,3 @@
-#define TEST_STATIC_HANDLER
-
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "request.h"

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -13,8 +13,9 @@ class MockNginxConfig : public NginxConfig {};
 class StaticHandlerTest : public ::testing::Test {
  protected:
   StaticHandlerTest() {
+    const std::string uri_prefix = "/static";
     ParseString("root ./example_files;");
-    status_ = static_handler.Init(uri_prefix_, config_);
+    status_ = static_handler_.Init(uri_prefix, config_);
     request_ = MockRequest::Parse(TEST_BUFFER);
   }
 
@@ -26,7 +27,7 @@ class StaticHandlerTest : public ::testing::Test {
   MockNginxConfig config_;
 
   StaticHandler static_handler_;
-  const std::string uri_prefix_ = "/static";
+  
   const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
   std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Server Test</title>\r\n</head>\r\n<body>\r\n<h1>Testing testing 1 2 3...</h1>\r\n<p>Looks like the server is working!</p>\r\n</body>\r\n</html>";
   RequestHandler::Status status_;

--- a/src/static_handler_test.cc
+++ b/src/static_handler_test.cc
@@ -11,36 +11,36 @@ class StaticHandlerTest : public ::testing::Test {
  protected:
   StaticHandlerTest() {
     ParseString("root ./example_files;");
-    status = static_handler.Init(uri_prefix, config);
-    request = Request::Parse(TEST_BUFFER);
+    status_ = static_handler.Init(uri_prefix_, config_);
+    request_ = Request::Parse(TEST_BUFFER);
   }
 
   bool ParseString(const std::string config_string) {
     std::stringstream config_stream(config_string);
-    return parser.Parse(&config_stream, &config);
+    return parser_.Parse(&config_stream, &config_);
   }
-  NginxConfigParser parser;
-  NginxConfig config;
+  NginxConfigParser parser_;
+  NginxConfig config_;
 
-  StaticHandler static_handler;
-  const std::string uri_prefix = "/static";
+  StaticHandler static_handler_;
+  const std::string uri_prefix_ = "/static";
   const std::string TEST_BUFFER = "GET /static/test.html HTTP/1.1\r\nUser-Agent: curl/7.35.0\r\nHost: localhost:2020\r\nAccept: */*\r\n\r\n";
   std::string EXPECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\r\n<html>\r\n<head>\r\n<title>Server Test</title>\r\n</head>\r\n<body>\r\n<h1>Testing testing 1 2 3...</h1>\r\n<p>Looks like the server is working!</p>\r\n</body>\r\n</html>";
-  RequestHandler::Status status;
-  std::unique_ptr<Request> request;
-  Response response;
+  RequestHandler::Status status_;
+  std::unique_ptr<Request> request_;
+  Response response_;
 };
 
 TEST_F(StaticHandlerTest, InitTest) {
-  EXPECT_EQ(status, RequestHandler::Status::OK);
+  EXPECT_EQ(status_, RequestHandler::Status::OK);
 }
 
 TEST_F(StaticHandlerTest, NullResponse) {
-  EXPECT_EQ(static_handler.HandleRequest(*request, nullptr), RequestHandler::Status::ERROR);
+  EXPECT_EQ(static_handler_.HandleRequest(*request_, nullptr), RequestHandler::Status::ERROR);
 }
 
 TEST_F(StaticHandlerTest, HandleProperRequestTest) {
-  EXPECT_EQ(static_handler.HandleRequest(*request, &response), RequestHandler::Status::OK);
-  EXPECT_EQ(response.GetResponseCode(), Response::OK);
-  EXPECT_EQ(response.ToString(), EXPECTED_RESPONSE);
+  EXPECT_EQ(static_handler_.HandleRequest(*request_, &response_), RequestHandler::Status::OK);
+  EXPECT_EQ(response_.GetResponseCode(), Response::OK);
+  EXPECT_EQ(response_.ToString(), EXPECTED_RESPONSE);
 }

--- a/src/status_handler_test.cc
+++ b/src/status_handler_test.cc
@@ -1,5 +1,3 @@
-#define TEST_STATUS_HANDLER
-
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "request.h"

--- a/src/status_handler_test.cc
+++ b/src/status_handler_test.cc
@@ -5,7 +5,6 @@
 #include "config_parser.h"
 #include "status_handler.h"
 
-class MockRequest : public Request {};
 class MockResponse : public Response {};
 class MockServerStatus : public ServerStatus {};
 
@@ -16,15 +15,15 @@ class StatusHandlerTest : public ::testing::Test {
     const NginxConfig config;
     status_ = status_handler_.Init(uri_prefix, config);
     server_status_.UpdateStatus("/echo", MockResponse::OK);
-    status_request_ = MockRequest::Parse(STATUS_BUFFER);
+    status_request_ = Request::Parse(STATUS_BUFFER);
     status_request_->setServerStatus(&server_status_);
   }
 
   StatusHandler status_handler_;
   const std::string STATUS_BUFFER = "GET /status HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
   const std::string EXPECTED_STATUS_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>Server Status</h1><h3>Handler Info</h3></br><h2>Total Requests: 1</h2><h5>Number of requests for \"/echo\"</h5><ul style=\"list-style-type:none\"><li>200: 1</li></ul></body></html>";
-  MockRequestHandler::Status status_;
-  std::unique_ptr<MockRequest> status_request_;
+  RequestHandler::Status status_;
+  std::unique_ptr<Request> status_request_;
   MockResponse status_response_;
   MockServerStatus server_status_;
 };

--- a/src/status_handler_test.cc
+++ b/src/status_handler_test.cc
@@ -5,38 +5,38 @@
 #include "request.h"
 #include "response.h"
 #include "config_parser.h"
-#include "echo_handler.h"
 #include "status_handler.h"
+
+class MockRequest : public Request {};
+class MockResponse : public Response {};
+class MockServerStatus : public ServerStatus {};
 
 class StatusHandlerTest : public ::testing::Test {
  protected:
   StatusHandlerTest() {
-    status = status_handler.Init(uri_prefix, config);
-    server_status.UpdateStatus("/echo", Response::OK);
-    status_request = Request::Parse(STATUS_BUFFER);
-    status_request->setServerStatus(&server_status);
+    const std::string uri_prefix;
+    const NginxConfig config;
+    status_ = status_handler_.Init(uri_prefix, config);
+    server_status_.UpdateStatus("/echo", MockResponse::OK);
+    status_request_ = MockRequest::Parse(STATUS_BUFFER);
+    status_request_->setServerStatus(&server_status_);
   }
 
-  EchoHandler echo_handler;
-  StatusHandler status_handler;
-  const std::string uri_prefix;
-  const NginxConfig config;
+  StatusHandler status_handler_;
   const std::string STATUS_BUFFER = "GET /status HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
   const std::string EXPECTED_STATUS_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>Server Status</h1><h3>Handler Info</h3></br><h2>Total Requests: 1</h2><h5>Number of requests for \"/echo\"</h5><ul style=\"list-style-type:none\"><li>200: 1</li></ul></body></html>";
-  RequestHandler::Status status;
-  std::unique_ptr<Request> echo_request;
-  std::unique_ptr<Request> status_request;
-  Response echo_response;
-  Response status_response;
-  ServerStatus server_status;
+  MockRequestHandler::Status status_;
+  std::unique_ptr<MockRequest> status_request_;
+  MockResponse status_response_;
+  MockServerStatus server_status_;
 };
 
 TEST_F(StatusHandlerTest, InitTest) {
-  EXPECT_EQ(status, RequestHandler::Status::OK);
+  EXPECT_EQ(status_, RequestHandler::Status::OK);
 }
 
 TEST_F(StatusHandlerTest, HandleProperRequestTest) {
-  EXPECT_EQ(status_handler.HandleRequest(*status_request, &status_response), RequestHandler::Status::OK);
-  EXPECT_EQ(status_response.GetResponseCode(), Response::OK);
-  EXPECT_EQ(status_response.ToString(), EXPECTED_STATUS_RESPONSE);
+  EXPECT_EQ(status_handler_.HandleRequest(*status_request_, &status_response_), RequestHandler::Status::OK);
+  EXPECT_EQ(status_response_.GetResponseCode(), MockResponse::OK);
+  EXPECT_EQ(status_response_.ToString(), EXPECTED_STATUS_RESPONSE);
 }

--- a/src/status_handler_test.cc
+++ b/src/status_handler_test.cc
@@ -1,0 +1,42 @@
+#define TEST_STATUS_HANDLER
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "request.h"
+#include "response.h"
+#include "config_parser.h"
+#include "echo_handler.h"
+#include "status_handler.h"
+
+class StatusHandlerTest : public ::testing::Test {
+ protected:
+  StatusHandlerTest() {
+    status = status_handler.Init(uri_prefix, config);
+    server_status.UpdateStatus("/echo", Response::OK);
+    status_request = Request::Parse(STATUS_BUFFER);
+    status_request->setServerStatus(&server_status);
+  }
+
+  EchoHandler echo_handler;
+  StatusHandler status_handler;
+  const std::string uri_prefix;
+  const NginxConfig config;
+  const std::string STATUS_BUFFER = "GET /status HTTP/1.1\r\nAccept-Language: en-us\r\n\r\nname=1";
+  const std::string EXPECTED_STATUS_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<!doctype html><html><body><h1>Server Status</h1><h3>Handler Info</h3></br><h2>Total Requests: 1</h2><h5>Number of requests for \"/echo\"</h5><ul style=\"list-style-type:none\"><li>200: 1</li></ul></body></html>";
+  RequestHandler::Status status;
+  std::unique_ptr<Request> echo_request;
+  std::unique_ptr<Request> status_request;
+  Response echo_response;
+  Response status_response;
+  ServerStatus server_status;
+};
+
+TEST_F(StatusHandlerTest, InitTest) {
+  EXPECT_EQ(status, RequestHandler::Status::OK);
+}
+
+TEST_F(StatusHandlerTest, HandleProperRequestTest) {
+  EXPECT_EQ(status_handler.HandleRequest(*status_request, &status_response), RequestHandler::Status::OK);
+  EXPECT_EQ(status_response.GetResponseCode(), Response::OK);
+  EXPECT_EQ(status_response.ToString(), EXPECTED_STATUS_RESPONSE);
+}


### PR DESCRIPTION
Providing examples for how to write tests for our handlers by writing unit tests for all our handlers.
Unit tests for: Not Found Handler, Echo Handler, Status Handler, Static Handler

We have decided to only test HoldingHandler in integration tests, since it's used for testing multithreading and contains an infinite loop.